### PR TITLE
Ability to fetch person data from sidekiq job

### DIFF
--- a/lib/rollbar/worker_data_extractor.rb
+++ b/lib/rollbar/worker_data_extractor.rb
@@ -1,0 +1,21 @@
+module Rollbar
+  module WorkerDataExtractor
+    def self.included(klass)
+      klass.extend(ClassMethods)
+    end
+
+    module ClassMethods
+      def extract_person_data_from_worker(worker)
+        return {} unless worker
+
+        person_data = begin
+          worker.rollbar_person_data
+        rescue StandardError
+          {}
+        end
+
+        person_data
+      end
+    end
+  end
+end

--- a/lib/rollbar/worker_methods.rb
+++ b/lib/rollbar/worker_methods.rb
@@ -1,0 +1,40 @@
+require 'rollbar/worker_data_extractor'
+require 'rollbar/util'
+
+module Rollbar
+  module WorkerMethods
+    include WorkerDataExtractor
+
+    def rollbar_person_data
+      user = nil
+      unless Rollbar::Util.method_in_stack_twice(:rollbar_person_data, __FILE__)
+        user = send(Rollbar.configuration.person_method)
+      end
+
+      # include id, username, email if non-empty
+      if user
+        {
+          :id => (begin
+            user.send(Rollbar.configuration.person_id_method)
+          rescue StandardError
+            nil
+          end),
+          :username => (begin
+            user.send(Rollbar.configuration.person_username_method)
+          rescue StandardError
+            nil
+          end),
+          :email => (begin
+            user.send(Rollbar.configuration.person_email_method)
+          rescue StandardError
+            nil
+          end)
+        }
+      else
+        {}
+      end
+    rescue NameError
+      {}
+    end
+  end
+end


### PR DESCRIPTION
Requires that your worker responds to 'current_user' in this example. Basically lifted the code from the rails implementation and followed a very similar approach to that.

Rather than forking rollbar, we could copy+extend rollbar's sidekiq middleware and replace it with our own during initialization: https://github.com/mperham/sidekiq/wiki/Middleware#server-middleware

See also: https://docs.rollbar.com/docs/person-tracking
